### PR TITLE
Enable CI workflow with GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ jobs:
           path: test-reports
           destination: test-reports
       - store_artifacts:
-          path: circleci-test-errors.txt
-          destination: circleci-errors
+          path: ci-test-errors.txt
+          destination: ci-errors
       - store_artifacts:
           path: sphinx-errors.txt
           destination: sphinx-errors

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Run examples
+
+on: [push]
+jobs:
+  examples:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Create Conda env
+      run: |
+        $CONDA/bin/conda install --name base --yes python=3.7 pip
+    - name: Install dependencies
+      run: |
+        echo $PWD
+        ls -lh .
+        $CONDA/bin/pip install --progress-bar=off -r requirements.txt
+        # $CONDA/bin/pip install --progress-bar=off git+https://github.com/idaes/idaes-pse
+        git clone https://github.com/idaes/idaes-pse
+        cd idaes-pse/
+        $CONDA/bin/pip install --progress-bar=off .
+        idaes get-extensions --platform ubuntu1804
+    - name: Run integration tests
+      run: |
+        # check if the working directory is preserved between steps
+        echo $PWD
+        ls -lh .
+        $CONDA/bin/pytest -m "not integration" tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,19 +9,18 @@ jobs:
     - name: Create Conda env
       run: |
         $CONDA/bin/conda install --name base --yes python=3.7 pip
-    - name: Install dependencies
+    - name: Install own dependencies
       run: |
         echo $PWD
         ls -lh .
         $CONDA/bin/pip install --progress-bar=off -r requirements.txt
-        # $CONDA/bin/pip install --progress-bar=off git+https://github.com/idaes/idaes-pse
-        git clone https://github.com/idaes/idaes-pse
-        cd idaes-pse/
-        $CONDA/bin/pip install --progress-bar=off .
-        idaes get-extensions --platform ubuntu1804
-    - name: Run integration tests
+    - name: Install IDAES
       run: |
-        # check if the working directory is preserved between steps
-        echo $PWD
-        ls -lh .
+        $CONDA/bin/pip install --progress-bar=off git+https://github.com/idaes/idaes-pse
+        $CONDA/bin/idaes --version
+    - name: Install IDAES extensions
+      run: |
+        $CONDA/bin/idaes get-extensions --platform ubuntu1804
+    - name: Run non-integration tests
+      run: |
         $CONDA/bin/pytest -m "not integration" tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Create Conda env
+    - name: Setup Conda env
+      # `conda activate` does not work properly because env vars are not persisted between steps
+      # to circumvent this, instead of creating and activating a new Conda env,
+      # we install the packages in the Conda base environment, which is active by default
+      # caveat: specify full path to executables in the $CONDA/bin directory
       run: |
         $CONDA/bin/conda install --name base --yes python=3.7 pip
     - name: Install own dependencies
@@ -24,3 +28,13 @@ jobs:
     - name: Run non-integration tests
       run: |
         $CONDA/bin/pytest -m "not integration" tests/
+    - name: Save Sphinx build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: sphinx-errors
+        file: sphinx-errors.txt
+    - name: Save test build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-errors
+        file: ci-test-errors.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         $CONDA/bin/idaes get-extensions --platform ubuntu1804
     - name: Run non-integration tests
       run: |
-        $CONDA/bin/pytest -m "not integration" tests/
+        $CONDA/bin/pytest --verbose -m "not integration" tests/
     - name: Save Sphinx build artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,9 +32,9 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: sphinx-errors
-        file: sphinx-errors.txt
+        path: sphinx-errors.txt
     - name: Save test build artifacts
       uses: actions/upload-artifact@v2
       with:
         name: test-errors
-        file: ci-test-errors.txt
+        path: ci-test-errors.txt

--- a/README-developer.md
+++ b/README-developer.md
@@ -62,6 +62,6 @@ You can run the `build.py` script in testing mode (see `-h` option for details) 
 to test the notebooks.
 
 A more limited set of notebooks to examine is configured in the
-`build-circleci.yml` file, which you can pass to the `--config` option of the build
+`build-ci.yml` file, which you can pass to the `--config` option of the build
 script. This will emulate how the code is tested on CircleCI during a pull request.
 

--- a/build-ci.yml
+++ b/build-ci.yml
@@ -1,6 +1,6 @@
 #
 # Configuration file for build.py,
-# to be used for testing and on CircleCI
+# to be used for testing and for CI
 
 # Paths used for all sections
 paths:
@@ -12,12 +12,13 @@ paths:
   html: _build/html
 # Settings for running and converting Jupyter Notebooks
 notebook:
-    num_workers: 2
+    num_workers: 1
     # continue on errors (otherwise stop)
     continue_on_error: true
     test_mode: true
+    timeout: 300
     # where to put error files. special values: '__stdout__',  '__stderr__'
-    error_file: circleci-test-errors.txt
+    error_file: ci-test-errors.txt
     # template file for the "_doc" wrapper RST file
     template: docs/jupyter_notebook_sphinx.tpl
     directories:

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -20,12 +20,12 @@ import build
 @pytest.fixture(scope="module")
 def settings_ci():
     os.chdir(_root)
-    return build.Settings(open("build-circleci.yml", "r"))
+    return build.Settings(open("build-ci.yml", "r"))
 
 
 @pytest.mark.component
 def test_convert_some_notebooks(settings_ci):
-    build._log.setLevel(logging.INFO)  # otherwise DEBUG for some reason
+    build._log.setLevel(logging.DEBUG)  # otherwise DEBUG for some reason
     os.chdir(_root)
     nb = build.NotebookBuilder(settings_ci)
     nb.build({"rebuild": True})
@@ -51,7 +51,7 @@ def test_run_all_notebooks():
     proc.wait()
     assert proc.returncode == 0
     # now run
-    cmd = ["python", "build.py",  "--config", "build-circleci.yml", "--test"]
+    cmd = ["python", "build.py",  "--config", "build-ci.yml", "--test"]
     proc = subprocess.Popen(cmd)
     proc.wait()
     assert proc.returncode == 0


### PR DESCRIPTION
## Summary

This PR adds the first GitHub actions CI workflow running the non-integration tests.

The current version of the workflow seems to be running just fine. That said, it doesn't have feature parity with the CircleCI version yet (e.g. currently runs only one version of Python), and I'd still like to streamline things a bit. However, in the interest of time, maybe it would be better to get this basic version in first, and then do the rest of the changes as a separate PR afterwards.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
