### PR TITLE
Add `pull_request` trigger for GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Run examples
 
-on: [push]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   examples:
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       # we install the packages in the Conda base environment, which is active by default
       # caveat: specify full path to executables in the $CONDA/bin directory
       run: |
-        $CONDA/bin/conda install --name base --yes python=3.7 pip
+        $CONDA/bin/conda install --quiet --yes --name base python=3.7 pip
     - name: Install own dependencies
       run: |
         echo $PWD


### PR DESCRIPTION
## Summary

This should cause the workflow to run on PR branches. Without this, #5 will not work correctly.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
