### PR TITLE
Fix issue 12 and extend CI tests to additional Python versions/OSes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         echo $PWD
         ls -lh .
-        python -m install --progress-bar=off -r requirements.txt
+        python -m pip install --progress-bar=off -r requirements.txt
     - name: Install IDAES
       run: |
         python -m pip install --progress-bar=off git+https://github.com/idaes/idaes-pse

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,19 @@ jobs:
         idaes --version
     - name: Install IDAES extensions
       run: |
-        idaes get-extensions --platform ubuntu1804
+        idaes get-extensions --verbose
+        # NOTE: these commands are Unix-shell specific 
+        # and will need to be changed if we want to test on CMD.exe/Powershell
+        find $(idaes data-directory) -ls
+        # add bin directory to $PATH (only valid for subsequent steps)
+        echo "$(idaes bin-directory)" >> $GITHUB_PATH
+    - name: Test access to executables
+      run: |
+        if [ "$RUNNER_OS" == "Windows" ]; then
+            ipopt.exe -v
+        else
+            ipopt -v
+        fi
     - name: Run non-integration tests
       run: |
         pytest --verbose -m "not integration" tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,36 +2,48 @@ name: Run examples
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
   examples:
-    runs-on: ubuntu-18.04
+    name: Build examples (py${{ matrix.python-version }}/${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # if fail-fast == true (the default), jobs for the remaining values in the matrix are cancelled
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.6'
+          - '3.7'
+        os:
+          - ubuntu-18.04
+          - windows-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Conda env
-      # `conda activate` does not work properly because env vars are not persisted between steps
-      # to circumvent this, instead of creating and activating a new Conda env,
-      # we install the packages in the Conda base environment, which is active by default
-      # caveat: specify full path to executables in the $CONDA/bin directory
-      run: |
-        $CONDA/bin/conda install --quiet --yes --name base python=3.7 pip
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Install own dependencies
       run: |
         echo $PWD
         ls -lh .
-        $CONDA/bin/pip install --progress-bar=off -r requirements.txt
+        python -m install --progress-bar=off -r requirements.txt
     - name: Install IDAES
       run: |
-        $CONDA/bin/pip install --progress-bar=off git+https://github.com/idaes/idaes-pse
-        $CONDA/bin/idaes --version
+        python -m pip install --progress-bar=off git+https://github.com/idaes/idaes-pse
+        idaes --version
     - name: Install IDAES extensions
       run: |
-        $CONDA/bin/idaes get-extensions --platform ubuntu1804
+        idaes get-extensions --platform ubuntu1804
     - name: Run non-integration tests
       run: |
-        $CONDA/bin/pytest --verbose -m "not integration" tests/
+        pytest --verbose -m "not integration" tests/
     - name: Save Sphinx build artifacts
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   examples:
     name: Build examples (py${{ matrix.python-version }}/${{ matrix.os }})

--- a/build.py
+++ b/build.py
@@ -114,8 +114,10 @@ _log.setLevel(logging.INFO)
 
 
 # This is a workaround for a bug in some versions of Tornado on Windows for Python 3.8
-# the sys.version_info check includes the micro version, so e.g. 3.7.1 will also evaluate to True
-if sys.platform == "win32" and sys.version_info > (3, 7):
+# this is the recommended fix for this according to e.g. https://github.com/tornadoweb/tornado#2608
+# it should be revisited with python>=3.9 or if a fix is implemented by e.g. Jupyter
+# the sys.version_info check includes the micro version, so e.g. 3.8.0 will also evaluate to True
+if sys.platform == "win32" and sys.version_info > (3, 8):
     import asyncio
 
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/build.py
+++ b/build.py
@@ -114,7 +114,8 @@ _log.setLevel(logging.INFO)
 
 
 # This is a workaround for a bug in some versions of Tornado on Windows for Python 3.8
-if sys.platform == "win32":
+# the sys.version_info check includes the micro version, so e.g. 3.7.1 will also evaluate to True
+if sys.platform == "win32" and sys.version_info > (3, 7):
     import asyncio
 
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())


### PR DESCRIPTION
## Fixes #12

## Proposed changes:
- Add an explicit Python version check to exclude incompatible versions from workaround
- Extend CI tests so that they run on Python version/OS combination matrix

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
