### PR TITLE
Make DMF examples more robust to Parmest output

### DIFF
--- a/src/Tutorials/Advanced/ParamEst/DMF_for_parameter_estimation_NRTL_using_unit_model_solution_testing.ipynb
+++ b/src/Tutorials/Advanced/ParamEst/DMF_for_parameter_estimation_NRTL_using_unit_model_solution_testing.ipynb
@@ -482,6 +482,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(parameters_1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove_cell",
@@ -491,13 +500,29 @@
    "outputs": [],
    "source": [
     "# Check for values of the parameter estimation problem\n",
-    "import pytest\n",
+    "import pytest, re\n",
     "\n",
-    "assert parameters_1[\"fs.properties.tau[('benzene', 'toluene')]\"] == pytest.approx(-0.906, 1e-2) \n",
-    "assert parameters_1[\"fs.properties.tau[('toluene', 'benzene')]\"] == pytest.approx(1.445, 1e-2)\n",
+    "def get_tau(d, chem1, chem2):\n",
+    "    found_key = None\n",
+    "    for key in d:\n",
+    "        if re.match(fr\"fs\\.properties\\.tau.*{chem1}.*{chem2}.*\", key):\n",
+    "            found_key = key\n",
+    "            break\n",
+    "    if found_key is None:\n",
+    "        raise KeyError(f\"Did not find any key for fs.properties.tau with '{chem1}' followed by '{chem2}'\")\n",
+    "    return d[found_key]\n",
     "\n",
-    "assert parameters_2[\"fs.properties.tau[('benzene', 'toluene')]\"] == pytest.approx(-1.02, 1e-2) \n",
-    "assert parameters_2[\"fs.properties.tau[('toluene', 'benzene')]\"] == pytest.approx(1.667, 1e-2)"
+    "# reformulate in simpler form using get_tau() function to be robust to formatting details of the keys\n",
+    "# returned by theta_est() above.\n",
+    "dmf_params = {}\n",
+    "for n, p_n in ((1, parameters_1), (2, parameters_2)):\n",
+    "    for chem1, chem2 in (('benzene', 'toluene'), ('toluene', 'benzene')):\n",
+    "        dmf_params[f\"{n}:{chem1[0]}{chem2[0]}\"] = get_tau(p_n, chem1, chem2)\n",
+    "        \n",
+    "assert dmf_params[\"1:bt\"] == pytest.approx(-0.906, 1e-2) \n",
+    "assert dmf_params[\"1:tb\"] == pytest.approx(1.445, 1e-2)\n",
+    "assert dmf_params[\"2:bt\"] == pytest.approx(-1.02, 1e-2) \n",
+    "assert dmf_params[\"2:tb\"] == pytest.approx(1.667, 1e-2)"
    ]
   },
   {
@@ -528,15 +553,15 @@
     "ds_s1 = _dmf.find_one(name=name)\n",
     "if not ds_s1:\n",
     "    ds_s1 = _dmf.new(name=name, desc=\"Solution for data subset 1\", data={'SSE': obj_value_1, 'parameters': \n",
-    "                                                                         {'tau': {'benzene,toluene': parameters_1[\"fs.properties.tau[('benzene', 'toluene')]\"],\n",
-    "                                                                                  'toluene,benzene': parameters_1[\"fs.properties.tau[('toluene', 'benzene')]\"]}}})\n",
+    "                                                                         {'tau': {'benzene,toluene': dmf_params[\"1:bt\"],\n",
+    "                                                                                  'toluene,benzene': dmf_params[\"1:tb\"]}}})\n",
     "    create_relation(ds_s1, Predicates.derived, ds_splits[0])\n",
     "name = \"BT NRTL est param2\"\n",
     "ds_s2 = _dmf.find_one(name=name)\n",
     "if not ds_s2:\n",
     "    ds_s2 = _dmf.new(name=name, desc=\"Solution for data subset 2\", data={'SSE': obj_value_2, 'parameters': \n",
-    "                                                                         {'tau': {'benzene,toluene': parameters_2[\"fs.properties.tau[('benzene', 'toluene')]\"],\n",
-    "                                                                                  'toluene,benzene': parameters_2[\"fs.properties.tau[('toluene', 'benzene')]\"]}}})\n",
+    "                                                                         {'tau': {'benzene,toluene': dmf_params[\"2:bt\"],\n",
+    "                                                                                  'toluene,benzene': dmf_params[\"2:tb\"]}}})\n",
     "\n",
     "    create_relation(ds_s2, Predicates.derived, ds_splits[1])\n",
     "# save relations (prints number of objects processed)\n",


### PR DESCRIPTION
## Fixes #30 
To address error encountered in https://github.com/IDAES/idaes-pse/pull/215

## Proposed changes:

Modify the notebook with the error
- add function to retrieve values in dict from theta_est, do regex matching instead of string match
- re-use the results by stashing values in local copy of dictionary with known keys

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
