### PR TITLE
Add pecos dependencies and examples to CI build config

### DIFF
--- a/build-ci.yml
+++ b/build-ci.yml
@@ -30,6 +30,7 @@ notebook:
       - source: Examples/SurrMod/PySMO
       - source: Examples/Tools
       - source: Examples/UnitModels
+      - source: Examples/Pecos
       - source: Tutorials/Advanced/ParamEst
       - source: Tutorials/Basics
 # Settings for building the notebook index page.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 sphinx
 sphinx_rtd_theme
 linkchecker==10.*
+
+# extra dependencies required by specific notebooks
+# used by notebooks in Examples/Pecos/
+pecos>=0.2.0


### PR DESCRIPTION
## Fixes #34 

## Proposed changes:
- Add pecos dependencies to `requirements.txt`, requiring minimum version for which the error in #34 has been fixed
- Add pecos notebooks to CI build configuration

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
