### PR TITLE
Address test failures due to ipopt checks and inconsistent notebook build order

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,6 @@ jobs:
     - name: Check installed versions
       run: |
         idaes --version
-        ipopt -v
         pandoc --version
     - name: Build notebook index
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,18 +47,6 @@ jobs:
     - name: Install IDAES extensions
       run: |
         idaes get-extensions --verbose
-        # NOTE: these commands are Unix-shell specific 
-        # and will need to be changed if we want to test on CMD.exe/Powershell
-        find $(idaes data-directory) -ls
-        # add bin directory to $PATH (only valid for subsequent steps)
-        echo "$(idaes bin-directory)" >> $GITHUB_PATH
-    - name: Test access to executables
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then
-            ipopt.exe -v
-        else
-            ipopt -v
-        fi
     - name: Run pytest (unit)
       run: |
         pytest --verbose -m unit tests/
@@ -94,8 +82,6 @@ jobs:
         python -m pip install --progress-bar=off git+https://github.com/idaes/idaes-pse
         idaes --version
         idaes get-extensions --verbose
-        # add bin directory to $PATH (only valid for subsequent steps)
-        echo "$(idaes bin-directory)" >> $GITHUB_PATH
         sudo apt-get install --quiet --yes pandoc
     - name: Check installed versions
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+  schedule:
+    # run daily at 5:00 am UTC (12 am ET/9 pm PT)
+    - cron: '0 5 * * *'
 
 defaults:
   run:

--- a/build.py
+++ b/build.py
@@ -1154,7 +1154,7 @@ class SphinxBuilder(Builder):
             else:
                 nb_output_dir = doc_dir / nb_dir["source"]
             _log.debug(f"find notebooks in path: {nb_output_dir}")
-            for nb_path in Path(nb_output_dir).glob("**/*.ipynb"):
+            for nb_path in sorted(Path(nb_output_dir).glob("**/*.ipynb")):
                 nb_dest = html_dir / nb_path.relative_to(doc_dir)
                 if not nb_dest.parent.exists():
                     nb_dest.parent.mkdir(parents=True)

--- a/build.py
+++ b/build.py
@@ -502,7 +502,6 @@ class NotebookBuilder(Builder):
         notebooks_to_convert, data_files = [], []
         # the return value of Path.iterdir() should be sorted to ensure consistency across different OSes
         for entry in sorted(srcdir.iterdir()):
-            print(f'entry: {entry}')
             filename = entry.parts[-1]
             if filename.startswith(".") or filename.startswith("__"):
                 _log.debug(f"skip special file '{entry}'")

--- a/build.py
+++ b/build.py
@@ -500,7 +500,9 @@ class NotebookBuilder(Builder):
 
         # Iterate through directory and get list of notebooks to convert (and data files)
         notebooks_to_convert, data_files = [], []
-        for entry in srcdir.iterdir():
+        # the return value of Path.iterdir() should be sorted to ensure consistency across different OSes
+        for entry in sorted(srcdir.iterdir()):
+            print(f'entry: {entry}')
             filename = entry.parts[-1]
             if filename.startswith(".") or filename.startswith("__"):
                 _log.debug(f"skip special file '{entry}'")
@@ -1154,7 +1156,7 @@ class SphinxBuilder(Builder):
             else:
                 nb_output_dir = doc_dir / nb_dir["source"]
             _log.debug(f"find notebooks in path: {nb_output_dir}")
-            for nb_path in sorted(Path(nb_output_dir).glob("**/*.ipynb")):
+            for nb_path in Path(nb_output_dir).glob("**/*.ipynb"):
                 nb_dest = html_dir / nb_path.relative_to(doc_dir)
                 if not nb_dest.parent.exists():
                     nb_dest.parent.mkdir(parents=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,8 @@ _root = os.path.join(os.path.dirname(__file__), "..")
 def _find_notebooks(p: Path, file_list):
     """Find all notebooks under path `p`, and add them to the file_list.
     """
-    for entry in p.iterdir():
+    # the return value of Path.iterdir() should be sorted to ensure consistency across different OSes
+    for entry in sorted(p.iterdir()):
         if entry.is_dir():
             _find_notebooks(entry, file_list)
         elif entry.name.endswith(".ipynb"):


### PR DESCRIPTION
## Fixes

Test failures in this repository failing because of updates in idaes-ext config ~(unrelated to integration tests failures in IDAES/idaes-pse#278)~ and inconsistent ordering in which notebooks were processed (see IDAES/idaes-pse#278).

## Proposed changes:
- Remove unnecessary PATH manipulation and explicit ipopt checks
- Add schedule trigger to run nightly tests
- Wrap calls to `Path.iterdir()` in `sorted()` so that notebooks are processed consistently across OSes

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
