### PR TITLE
Removing bootstrap from parmest notebooks

### DIFF
--- a/src/Tutorials/Advanced/ParamEst/parameter_estimation_NRTL_using_state_block_solution_testing.ipynb
+++ b/src/Tutorials/Advanced/ParamEst/parameter_estimation_NRTL_using_state_block_solution_testing.ipynb
@@ -537,7 +537,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pyomo's `parmest` tool allows for bootstrapping where the parameter estimation is repeated over `n` samples with resampling from the original data set. Parameter estimation with bootstrap resampling can be used to identify confidence regions around each parameter estimate.  This analysis can be slow given the increased number of model instances that need to be solved.  In the following cell, we run the parameter estimation with 10 bootstrap samples from the given dataset.  We then plot the parameter estimates along with an confidence regions using rectangular and multivariate normal distributions."
+    "Pyomo's `parmest` tool allows for bootstrapping where the parameter estimation is repeated over `n` samples with resampling from the original data set. Parameter estimation with bootstrap resampling can be used to identify confidence regions around each parameter estimate.  This analysis can be slow given the increased number of model instances that need to be solved. Please refer to https://pyomo.readthedocs.io/en/stable/contributed_packages/parmest/driver.html for more details. \n",
+    "\n",
+    "For the example above, the bootstrapping can be run by uncommenting the code in the following cell:"
    ]
   },
   {
@@ -548,7 +550,10 @@
    "source": [
     "# Run parameter estimation using bootstrap resample of the data (10 samples),\n",
     "# plot results along with confidence regions\n",
-    "bootstrap_theta = pest.theta_est_bootstrap(4)"
+    "\n",
+    "# Uncomment the following code:\n",
+    "# bootstrap_theta = pest.theta_est_bootstrap(4)\n",
+    "# display(bootstrap_theta)"
    ]
   },
   {
@@ -556,9 +561,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "display(bootstrap_theta)"
-   ]
+   "source": []
   },
   {
    "cell_type": "code",

--- a/src/Tutorials/Advanced/ParamEst/parameter_estimation_NRTL_using_unit_model_solution_testing.ipynb
+++ b/src/Tutorials/Advanced/ParamEst/parameter_estimation_NRTL_using_unit_model_solution_testing.ipynb
@@ -541,7 +541,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pyomo's `parmest` tool allows for bootstrapping where the parameter estimation is repeated over `n` samples with resampling from the original data set. Parameter estimation with bootstrap resampling can be used to identify confidence regions around each parameter estimate.  This analysis can be slow given the increased number of model instances that need to be solved.  In the following cell, we run the parameter estimation with 10 bootstrap samples from the given dataset.  We then plot the parameter estimates along with an confidence regions using rectangular and multivariate normal distributions. "
+    "Pyomo's `parmest` tool allows for bootstrapping where the parameter estimation is repeated over `n` samples with resampling from the original data set. Parameter estimation with bootstrap resampling can be used to identify confidence regions around each parameter estimate.  This analysis can be slow given the increased number of model instances that need to be solved. Please refer to https://pyomo.readthedocs.io/en/stable/contributed_packages/parmest/driver.html for more details. \n",
+    "\n",
+    "For the example above, the bootstrapping can be run by uncommenting the code in the following cell:"
    ]
   },
   {
@@ -552,24 +554,12 @@
    "source": [
     "# Run parameter estimation using bootstrap resample of the data (10 samples),\n",
     "# plot results along with confidence regions\n",
-    "bootstrap_theta = pest.theta_est_bootstrap(4)"
+    "\n",
+    "# Uncomment the following lines\n",
+    "\n",
+    "# bootstrap_theta = pest.theta_est_bootstrap(4)\n",
+    "# display(bootstrap_theta)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "display(bootstrap_theta)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Fixes # .

https://github.com/IDAES/idaes-pse/issues/293 

## Proposed changes:
- Removing bootstrap cell in the parmest notebooks as this could be the reason for unpredictable convergence problems and long run times. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
