### PR TITLE
Use new syntax for installing prerelease IDAES in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         python -m pip install --progress-bar=off -r requirements.txt
     - name: Install IDAES
       run: |
-        python -m pip install --progress-bar=off git+https://github.com/idaes/idaes-pse
+        python -m pip install --progress-bar=off 'idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
         idaes --version
     - name: Install IDAES extensions
       run: |
@@ -82,7 +82,7 @@ jobs:
       run: |
         python -m pip install --progress-bar=off setuptools pip wheel
         python -m pip install --progress-bar=off -r requirements.txt
-        python -m pip install --progress-bar=off git+https://github.com/idaes/idaes-pse
+        python -m pip install --progress-bar=off 'idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip'
         idaes --version
         idaes get-extensions --verbose
         sudo apt-get install --quiet --yes pandoc


### PR DESCRIPTION
## Motivation

When running CI checks for testing the examples, IDAES should be installed from main with prerelease dependencies. Following IDAES/idaes-pse#292, it is possible to do so in a single `pip install` command by using the `[prerelease]` tag: `pip install "idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip"`.


## Proposed changes:
- Update syntax for `pip install`ing IDAES in GHA

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
