### PR TITLE
Removing pyutilib dependency

### DIFF
--- a/src/Examples/SurrMod/ALAMO/ALAMO_six_hump_camel.ipynb
+++ b/src/Examples/SurrMod/ALAMO/ALAMO_six_hump_camel.ipynb
@@ -79,7 +79,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Fixes None .

With the move to Pyomo 6, the pyutilib dependency is being removes, thus any imports from there need to be updated.

## Proposed changes:
- Replace import of `ApplicationError` from pyutilib with one from Pyomo common.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
