### PR TITLE
Build configuration to address #53

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,7 @@ jobs:
     - name: Check for undetected errors in HTML output
       shell: bash
       run: |
+        grep "WARNING: Could not locate" -r ./docs_test/_build/html/ ; test $? -eq 1
         grep "size limits exceeded" -r ./docs_test/_build/html/ ; test $? -eq 1
     - name: Check for broken links in HTML docs
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,10 @@ jobs:
       with:
         name: sphinx-error-logs
         path: sphinx-errors.txt
+    - name: Check for undetected errors in HTML output
+      shell: bash
+      run: |
+        grep "size limits exceeded" -r ./docs_test/_build/html/ ; test $? -eq 1
     - name: Check for broken links in HTML docs
       shell: bash
       run: |

--- a/build.yml
+++ b/build.yml
@@ -31,21 +31,7 @@ notebook:
     # string is a regular expression that acts as a filter: only files that
     # have that expression (here a simple string) in them will be processed.
     directories:
-      - source: Examples/Advanced/CustomUnitModels
-      - source: Examples/Advanced/CustomProperties
-      - source: Examples/Advanced/DataRecon
-      - source: Examples/Flowsheets
       - source: Examples/MatOpt
-      - source: Examples/SurrMod/ALAMO
-      - source: Examples/SurrMod/Helmet
-      - source: Examples/SurrMod/PySMO
-#      - source: Examples/SurrMod/RIPE
-#        match: "RIPE_.*"
-      - source: Examples/Tools
-      - source: Examples/UnitModels
-      - source: Examples/Pecos
-      - source: Tutorials/Advanced/ParamEst
-      - source: Tutorials/Basics
 # Settings for building the notebook index page.
 # These can be overridden with options to the script.
 notebook_index:


### PR DESCRIPTION
# DO NOT MERGE

This PR is being used to facilitate the steps needed to address #53 in the short term, and is not supposed to be merged into `main` as-is.

## Instructions

Check out the code in this PR:

```sh
mkdir idaes-examples-pr-54 && cd idaes-examples-pr-54

git clone https://github.com/IDAES/examples-pse && cd examples-pse
git fetch origin pull/54/head:pr-54
git checkout pr-54
```

If not already present, install pandoc for your system using the instructions here: (https://pandoc.org/installing.html).

> **NOTE**: pip cannot be used to install pandoc. The `pandoc` package on PyPI is not the pandoc that is needed for the `examples-pse` build; rather, it provides Python bindings to pandoc, and requires pandoc to be installed separately

From an environment where IDAES is installed and fully enabled:

```sh
pip install -r requirements.txt
python build.py --config build.yml -cdr -v -w 1
```

There will be some warnings due to the missing notebooks that have been removed from the build config file just for this PR; they can be ignored.

Once the build succeeds, you can use a web browser to verify that the HTML output is OK by opening the `index.html` file in the desired directory, and then browsing as normal to the remaining pages, e.g.:

```sh
firefox docs/_build/html/Examples/MatOpt/index.html
```