### PR TITLE
Updating ALAMO example with deprecated path

### DIFF
--- a/src/Examples/SurrMod/ALAMO/ALAMO_six_hump_camel.ipynb
+++ b/src/Examples/SurrMod/ALAMO/ALAMO_six_hump_camel.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from idaes.surrogate import alamopy\n",
+    "from idaes.surrogate import alamopy_depr as alamopy\n",
     "import examples\n",
     "import pyomo.environ as pyo\n",
     "from pyomo.common.errors import ApplicationError\n",

--- a/src/Examples/SurrMod/ALAMO/ackley.py
+++ b/src/Examples/SurrMod/ALAMO/ackley.py
@@ -16,7 +16,7 @@
 # The function is corrupted by normally distributed noise of varaince 0.1
 
 
-from idaes.surrogate import alamopy
+from idaes.surrogate import alamopy_depr as alamopy
 
 #Import additional python modules for creating the synthetic data
 import math

--- a/src/Examples/SurrMod/ALAMO/branin.py
+++ b/src/Examples/SurrMod/ALAMO/branin.py
@@ -14,7 +14,7 @@
 # More information on the branin function can be found at
 # https://www.sfu.ca/~ssurjano/branin.html
 
-from idaes.surrogate import alamopy
+from idaes.surrogate import alamopy_depr as alamopy
 
 #Import additional python modules for creating the synthetic data
 import math

--- a/src/Examples/SurrMod/ALAMO/camel6.py
+++ b/src/Examples/SurrMod/ALAMO/camel6.py
@@ -14,7 +14,7 @@
 # More information on this function can be found at :
 #            https://www.sfu.ca/~ssurjano/camel6.html
 # This problem utilizes ALAMO's sampling features
-from idaes.surrogate import alamopy
+from idaes.surrogate import alamopy_depr as alamopy
 
 # Import additional python modules for creating the synthetic data
 import math


### PR DESCRIPTION
## Fixes deprecated paths from https://github.com/IDAES/idaes-pse/pull/455 .

These examples will eventually be replaced by updated versions using the new interface, but for now we will just update the path to keep things running.

## Proposed changes:
- Update paths in ALAMO examples with the deprecated path to the old alamopy wrapper.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
