### PR TITLE
Remove hardcoded value for idaes-pse requirement from requirements file

### DIFF
--- a/.github/actions/setup-idaes/action.yml
+++ b/.github/actions/setup-idaes/action.yml
@@ -24,6 +24,9 @@ runs:
     - name: Install idaes and dependencies
       shell: bash -l {0}
       run: |
+        echo '::group::Contents of requirements.txt'
+        cat requirements.txt
+        echo '::endgroup::'
         echo '::group::Output of "pip install" command'
         ${{ inputs.install-command }} ${{ inputs.install-target}}
         echo '::endgroup::'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   IDAES_CONDA_ENV_NAME_DEV: examples-pse-dev
+  IDAES_PSE_REQUIREMENT: idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip
 
 defaults:
   run:
@@ -52,6 +53,9 @@ jobs:
       if: matrix.skip-wsl-only
       run: |
         rm -r src/Examples/DAE/petsc*.ipynb
+    - name: Add configured version of idaes-pse to requirements
+      run: |
+        echo "$IDAES_PSE_REQUIREMENT" >> requirements.txt
     - name: Set up IDAES
       uses: ./.github/actions/setup-idaes
       with:
@@ -86,6 +90,9 @@ jobs:
         activate-environment: ${{ env.IDAES_CONDA_ENV_NAME_DEV }}
         python-version: ${{ matrix.python-version }}
     - uses: actions/checkout@v2
+    - name: Add configured version of idaes-pse to requirements
+      run: |
+        echo "$IDAES_PSE_REQUIREMENT" >> requirements.txt
     - name: Set up IDAES
       uses: ./.github/actions/setup-idaes
       with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,3 @@ linkchecker==10.*
 # extra dependencies required by specific notebooks
 # used by notebooks in Examples/Pecos/
 pecos>=0.2.0
-
-# IDAES: install from current main
-idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip


### PR DESCRIPTION
## Motivation
- Having the `idaes-pse` requirement inside the `requirements.txt` file makes it harder to change it programmatically when needed (e.g. to use a released version of `idaes-pse` instead of the default)
- If `requirements.txt` contains all other requirements except the one for `idaes-pse`, it's easy to add it before installation with e.g. `echo "idaes-pse[prerelease] @ git+ssh://my-git-server:idaes-pse.git" >> requirements.txt`

## Proposed changes:
- Remove the requirement for `idaes-pse` from `requirements.txt`
- Tweak the GHA workflow and `setup-idaes` actions to configure and append the `idaes-pse` requirement before installation

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
