### PR TITLE
Track import path changes for DMF

### DIFF
--- a/src/Examples/Advanced/DataRecon/boiler_flowsheet_recon_testing.ipynb
+++ b/src/Examples/Advanced/DataRecon/boiler_flowsheet_recon_testing.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "# IDAES module with functions to read, analyze and visualize plant data\n",
-    "import idaes.dmf.model_data as da"
+    "import idaes.core.dmf.model_data as da"
    ]
   },
   {

--- a/src/Examples/Advanced/DataRecon/econ_parmest_testing.ipynb
+++ b/src/Examples/Advanced/DataRecon/econ_parmest_testing.ipynb
@@ -25,7 +25,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "import idaes.dmf.model_data as da\n",
+    "import idaes.core.dmf.model_data as da\n",
     "from idaes.logger import getLogger\n",
     "import logging\n",
     "getLogger('idaes.core').setLevel(logging.ERROR)"

--- a/src/Examples/Advanced/DataRecon/econ_recon_testing.ipynb
+++ b/src/Examples/Advanced/DataRecon/econ_recon_testing.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "# IDAES module with functions to read, analyze and visualize plant data\n",
-    "import idaes.dmf.model_data as da\n",
+    "import idaes.core.dmf.model_data as da\n",
     "# Suppress some warnings\n",
     "from idaes.logger import getLogger\n",
     "import logging\n",

--- a/src/Examples/Tools/data_management_framework.ipynb
+++ b/src/Examples/Tools/data_management_framework.ipynb
@@ -92,7 +92,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from idaes.dmf import DMF  # import main class\n",
+    "from idaes.core.dmf import DMF  # import main class\n",
     "import shutil, os\n",
     "\n",
     "workspace_dir = \"my_workspace\"\n",
@@ -159,7 +159,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from idaes.dmf.resource import Resource, ResourceTypes\n",
+    "from idaes.core.dmf.resource import Resource, ResourceTypes\n",
     "\n",
     "# Add the Flash code block as a resource\n",
     "flash_code = Resource(type_=ResourceTypes.code, value={\n",
@@ -235,7 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from idaes.dmf.resource import create_relation, Predicates\n",
+    "from idaes.core.dmf.resource import create_relation, Predicates\n",
     "\n",
     "create_relation(flash_code, Predicates.uses, inlet_params)\n",
     "dmf.update()  # sync to DMF storage"
@@ -333,7 +333,7 @@
     "<div class=\"alert alert-block alert-info\">\n",
     "    &#9998; <b>Details:</b>\n",
     "A full description of possible fields (i.e., a schema) for a resource is in\n",
-    "    <span style=\"font-family:monospace\">idaes.dmf.resource.RESOURCE_SCHEMA</span>. The syntax for this description is a standard called <a href=\"https://json-schema.org\">JSON Schema</a>.\n",
+    "    <span style=\"font-family:monospace\">idaes.core.dmf.resource.RESOURCE_SCHEMA</span>. The syntax for this description is a standard called <a href=\"https://json-schema.org\">JSON Schema</a>.\n",
     "    </div>\n",
     "    \n",
     "For the purposes of understanding this query, you need to know 3 things:\n",
@@ -498,7 +498,7 @@
    "outputs": [],
    "source": [
     "# Need to import this to register the magics with your Jupyter Notebook\n",
-    "from idaes.dmf import magics"
+    "from idaes.core.dmf import magics"
    ]
   },
   {

--- a/src/Tutorials/Advanced/ParamEst/DMF_1_for_parameter_estimation_NRTL_using_unit_model_solution_testing.ipynb
+++ b/src/Tutorials/Advanced/ParamEst/DMF_1_for_parameter_estimation_NRTL_using_unit_model_solution_testing.ipynb
@@ -301,8 +301,8 @@
    "source": [
     "# DMF imports\n",
     "from pathlib import Path\n",
-    "from idaes.dmf import DMF, magics\n",
-    "from idaes.dmf.resource import Resource, create_relation, Predicates\n",
+    "from idaes.core.dmf import DMF, magics\n",
+    "from idaes.core.dmf.resource import Resource, create_relation, Predicates\n",
     "# use or create idaes \"dotfile\" in home directory\n",
     "wspath = Path(\"~/.idaes\").expanduser()\n",
     "if not wspath.exists():\n",

--- a/src/Tutorials/Advanced/ParamEst/DMF_2_flash_unit_Model_with_NRTL_solution_testing.ipynb
+++ b/src/Tutorials/Advanced/ParamEst/DMF_2_flash_unit_Model_with_NRTL_solution_testing.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from idaes.dmf import DMF, magics\n",
+    "from idaes.core.dmf import DMF, magics\n",
     "from pathlib import Path\n",
     "idaes_home = Path(\"~/.idaes\").expanduser()\n",
     "if not idaes_home.exists():\n",


### PR DESCRIPTION
## Summary/Motivation:
- Import path for DMF changed from `idaes.dmf` to `idaes.core.dmf` (IDAES/idaes-pse#853)
- Import paths in the examples should be update to track this change

## Proposed changes:

- `sed /idaes.dmf/idaes.core.dmf/g *.ipynb`

## For reviewers

- :chicken: / :egg: Checks on this PR are expected to fail until IDAES/idaes-pse#853 is merged into `IDAES/idaes-pse:main`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
