### PR TITLE
Unpin TensorFlow and Protobuf Versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,6 @@ linkchecker==10.*
 # extra dependencies required by specific notebooks
 # used by notebooks in Examples/Pecos/
 pecos>=0.2.0
-# used by notebooks in Examples/SurrMod/FlowsheetOptimization
-tensorflow==2.8.1
-# as of 6/13/2022, latest version 4.21.1 breaks tensorflow import
-# pinning to older, stable version
-protobuf==3.20.1
 
 # editable dependencies to be installed during setup
 --editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,9 @@ linkchecker==10.*
 pecos>=0.2.0
 
 # used by notebooks in Examples/SurrMod/FlowsheetOptimization
-tensorflow
-protobuf
+# pinning to latest stable version as of 9/29/2022
+tensorflow==2.10.0
+protobuf==3.19.5
 
 # editable dependencies to be installed during setup
 --editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ linkchecker==10.*
 # used by notebooks in Examples/Pecos/
 pecos>=0.2.0
 
+# used by notebooks in Examples/SurrMod/FlowsheetOptimization
+tensorflow
+protobuf
+
 # editable dependencies to be installed during setup
 --editable .
 


### PR DESCRIPTION
## Fixes # .


## Proposed changes:
- Now that dependabot wants to update `protobuf` from 3.20.1 to 3.20.2, it's worth checking if we can just unpin `protobuf`. We originally pinned this for compatiability with `tensorflow` version 2.8.1, so both must be unpinned to test this.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
