### PR TITLE
Fix Leftover Default Argument In ALAMO Notebook

### DIFF
--- a/src/Examples/SurrMod/FlowsheetOptimization/ALAMO_flowsheet_optimization.ipynb
+++ b/src/Examples/SurrMod/FlowsheetOptimization/ALAMO_flowsheet_optimization.ipynb
@@ -2035,7 +2035,7 @@
    "source": [
     "# create the IDAES model and flowsheet\n",
     "m = ConcreteModel()\n",
-    "m.fs = FlowsheetBlock(default={\"dynamic\": False})\n",
+    "m.fs = FlowsheetBlock(dynamic=False)\n",
     "\n",
     "# create flowsheet input variables\n",
     "m.fs.bypass_frac = Var(initialize=0.80, bounds=[0.1, 0.8], doc='natural gas bypass fraction')\n",


### PR DESCRIPTION
## Fixes # .


## Proposed changes:
- I found a "default" argument that was not updated. I quickly checked the rest of the Python scripts and notebooks, and I think this is the only leftover usage of the deprecated "default=" argument in the examples.
- Side note ~ I thought we had a test that checks for this?

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
