### PR TITLE
Configure GHA run serialization to automatically cancel redundant workflow runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,13 @@ on:
     # run daily at 5:00 am UTC (12 am ET/9 pm PT)
     - cron: '0 5 * * *'
 
+concurrency:
+  # NOTE: the value of `group` should be chosen carefully,
+  # otherwise we might end up over- or under-canceling workflow runs
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+  # comment to remove to test this block
+
 env:
   IDAES_CONDA_ENV_NAME_DEV: examples-pse-dev
   IDAES_PSE_REQUIREMENT: idaes-pse[prerelease] @ https://github.com/IDAES/idaes-pse/archive/main.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ concurrency:
   # otherwise we might end up over- or under-canceling workflow runs
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
-  # comment to remove to test this block
 
 env:
   IDAES_CONDA_ENV_NAME_DEV: examples-pse-dev


### PR DESCRIPTION
## Fixes # .


## Proposed changes:
- This update configures examples-pse to cancel redundant workflow runs, similar to the update implemented in https://github.com/IDAES/idaes-pse/pull/854

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
