### PR TITLE
Update property metadata

### DIFF
--- a/pkg/idaes_examples/common/hda/hda_ideal_VLE.py
+++ b/pkg/idaes_examples/common/hda/hda_ideal_VLE.py
@@ -376,44 +376,35 @@ class HDAParameterData(PhysicalParameterBlock):
     def define_metadata(cls, obj):
         """Define properties supported and units."""
         obj.add_properties(
-            {'flow_mol': {'method': None, 'units': 'mol/s'},
-             'flow_mol_phase_comp': {'method': None, 'units': 'mol/s'},
-             'mole_frac_comp': {'method': None, 'units': 'none'},
-             'temperature': {'method': None, 'units': 'K'},
-             'pressure': {'method': None, 'units': 'Pa'},
-             'flow_mol_phase': {'method': None, 'units': 'mol/s'},
-             'dens_mol_phase': {'method': '_dens_mol_phase',
-                                'units': 'mol/m^3'},
-             'pressure_sat': {'method': '_pressure_sat', 'units': 'Pa'},
-             'mole_frac_phase_comp': {'method': '_mole_frac_phase',
-                                      'units': 'no unit'},
+            {'flow_mol': {'method': None},
+             'flow_mol_phase_comp': {'method': None},
+             'mole_frac_comp': {'method': None},
+             'temperature': {'method': None},
+             'pressure': {'method': None},
+             'flow_mol_phase': {'method': None},
+             'dens_mol_phase': {'method': '_dens_mol_phase'},
+             'pressure_sat': {'method': '_pressure_sat'},
+             'mole_frac_phase_comp': {'method': '_mole_frac_phase'},
              'energy_internal_mol_phase_comp': {
-                     'method': '_energy_internal_mol_phase_comp',
-                     'units': 'J/mol'},
+                     'method': '_energy_internal_mol_phase_comp'},
              'energy_internal_mol_phase': {
-                     'method': '_enenrgy_internal_mol_phase',
-                     'units': 'J/mol'},
-             'enth_mol_phase_comp': {'method': '_enth_mol_phase_comp',
-                                     'units': 'J/mol'},
-             'enth_mol_phase': {'method': '_enth_mol_phase',
-                                'units': 'J/mol'},
-             'entr_mol_phase_comp': {'method': '_entr_mol_phase_comp',
-                                     'units': 'J/mol'},
-             'entr_mol_phase': {'method': '_entr_mol_phase',
-                                'units': 'J/mol'},
-             'temperature_bubble': {'method': '_temperature_bubble',
-                                    'units': 'K'},
-             'temperature_dew': {'method': '_temperature_dew',
-                                 'units': 'K'},
-             'pressure_bubble': {'method': '_pressure_bubble',
-                                 'units': 'Pa'},
-             'pressure_dew': {'method': '_pressure_dew',
-                              'units': 'Pa'},
-             'fug_vap': {'method': '_fug_vap', 'units': 'Pa'},
-             'fug_liq': {'method': '_fug_liq', 'units': 'Pa'},
-             'dh_vap': {'method': '_dh_vap', 'units': 'J/mol'},
-             'ds_vap': {'method': '_ds_vap', 'units': 'J/mol.K'}})
+                     'method': '_enenrgy_internal_mol_phase'},
+             'enth_mol_phase_comp': {'method': '_enth_mol_phase_comp'},
+             'enth_mol_phase': {'method': '_enth_mol_phase'},
+             'entr_mol_phase_comp': {'method': '_entr_mol_phase_comp'},
+             'entr_mol_phase': {'method': '_entr_mol_phase'},
+             'temperature_bubble': {'method': '_temperature_bubble'},
+             'temperature_dew': {'method': '_temperature_dew'},
+             'pressure_bubble': {'method': '_pressure_bubble'},
+             'pressure_dew': {'method': '_pressure_dew'},
+             'fug_vap_comp': {'method': '_fug_vap_comp'},
+             'fug_liq_comp': {'method': '_fug_liq_comp'},
+             })
 
+        obj.define_custom_properties(
+            {'dh_vap': {'method': '_dh_vap', "units": obj.derived_units.ENERGY_MOLE},
+             'ds_vap': {'method': '_ds_vap', "units": obj.derived_units.ENERGY_MASS}})
+        
         obj.add_default_units({'time': pyunits.s,
                                'length': pyunits.m,
                                'mass': pyunits.kg,
@@ -683,7 +674,7 @@ class IdealStateBlockData(StateBlockData):
                     doc='Component reduced temperatures')
 
             def rule_equilibrium(b, i):
-                return b.fug_vap[i] == b.fug_liq[i]
+                return b.fug_vap_comp[i] == b.fug_liq_comp[i]
             self.equilibrium_constraint = Constraint(
                     self._params.component_list, rule=rule_equilibrium)
 
@@ -1053,14 +1044,14 @@ class IdealStateBlockData(StateBlockData):
                  b._params.dens_liq_param_4[j])
                 for j in ['benzene', 'toluene'])
 
-    def _fug_liq(self):
-        def fug_liq_rule(b, i):
+    def _fug_liq_comp(self):
+        def fug_liq_comp_rule(b, i):
             if i in ['hydrogen', 'methane']:
                 return b.mole_frac_phase_comp['Liq', i]
             else:
                 return b.pressure_sat[i] * b.mole_frac_phase_comp['Liq', i]
-        self.fug_liq = Expression(self._params.component_list,
-                                  rule=fug_liq_rule)
+        self.fug_liq_comp = Expression(self._params.component_list,
+                                  rule=fug_liq_comp_rule)
 
     def _pressure_sat(self):
         self.pressure_sat = Var(self._params.component_list,
@@ -1112,14 +1103,14 @@ class IdealStateBlockData(StateBlockData):
                               const.gas_constant *
                               b.temperature)
 
-    def _fug_vap(self):
-        def fug_vap_rule(b, i):
+    def _fug_vap_comp(self):
+        def fug_vap_comp_rule(b, i):
             if i in ['hydrogen', 'methane']:
                 return 1e-6
             else:
                 return b.mole_frac_phase_comp['Vap', i] * b.pressure
-        self.fug_vap = Expression(self._params.component_list,
-                                  rule=fug_vap_rule)
+        self.fug_vap_comp = Expression(self._params.component_list,
+                                  rule=fug_vap_comp_rule)
 
     def _dh_vap(self):
         # heat of vaporization

--- a/pkg/idaes_examples/common/hda/hda_ideal_VLE.py
+++ b/pkg/idaes_examples/common/hda/hda_ideal_VLE.py
@@ -388,7 +388,7 @@ class HDAParameterData(PhysicalParameterBlock):
              'energy_internal_mol_phase_comp': {
                      'method': '_energy_internal_mol_phase_comp'},
              'energy_internal_mol_phase': {
-                     'method': '_enenrgy_internal_mol_phase'},
+                     'method': '_energy_internal_mol_phase'},
              'enth_mol_phase_comp': {'method': '_enth_mol_phase_comp'},
              'enth_mol_phase': {'method': '_enth_mol_phase'},
              'entr_mol_phase_comp': {'method': '_entr_mol_phase_comp'},

--- a/src/Examples/Advanced/CustomUnitModels/methanol_param_VLE.py
+++ b/src/Examples/Advanced/CustomUnitModels/methanol_param_VLE.py
@@ -108,7 +108,6 @@ class PhysicalParameterData(PhysicalParameterBlock):
              4: ["CH3OH", ("Vap", "Liq")]}
 
         # Antoine coefficients assume pressure in mmHG and temperature in K
-        # Antoine coefficients assume pressure in mmHG and temperature in K
         self.vapor_pressure_coeff = {('CH4', 'A'): 15.2243,
                                      ('CH4', 'B'): 897.84,
                                      ('CH4', 'C'): -7.16,

--- a/src/Examples/Advanced/CustomUnitModels/methanol_param_VLE.py
+++ b/src/Examples/Advanced/CustomUnitModels/methanol_param_VLE.py
@@ -108,6 +108,7 @@ class PhysicalParameterData(PhysicalParameterBlock):
              4: ["CH3OH", ("Vap", "Liq")]}
 
         # Antoine coefficients assume pressure in mmHG and temperature in K
+        # Antoine coefficients assume pressure in mmHG and temperature in K
         self.vapor_pressure_coeff = {('CH4', 'A'): 15.2243,
                                      ('CH4', 'B'): 897.84,
                                      ('CH4', 'C'): -7.16,
@@ -146,13 +147,12 @@ class PhysicalParameterData(PhysicalParameterBlock):
              'temperature': {'method': None},
              'pressure': {'method': None},
              'flow_mol_phase': {'method': None},
-             'density_mol': {'method': '_density_mol'},
-             'vapor_pressure': {'method': '_vapor_pressure'},
-             'mole_frac_phase': {'method': '_mole_frac_phase'},
-             'enthalpy_comp_liq': {'method': '_enthalpy_comp_liq'},
-             'enthalpy_comp_vap': {'method': '_enthalpy_comp_vap'},
-             'enthalpy_liq': {'method': '_enthalpy_liq'},
-             'enthalpy_vap': {'method': '_enthalpy_vap'}})
+             'dens_mol_phase': {'method': '_dens_mol_phase'},
+             'mole_frac_phase': {'method': '_mole_frac_phase'}})
+
+        obj.define_custom_properties(
+            {'vapor_pressure': {'method': '_vapor_pressure',
+                                'units': obj.derived_units.PRESSURE}})
 
         obj.add_default_units({'time': pyunits.s,
                                'length': pyunits.m,


### PR DESCRIPTION
https://github.com/IDAES/idaes-pse/pull/995 changes how metadata is defined for property packages, and enforces standard naming conventions (or at least forces users to explicitly declare non-standard names). This revealed that some of our examples were using non-standard names, which this PR addresses.

This PR will likely fail without the changes in `idaes-pse`, but this will be necessary to test those changes.

## Proposed changes:
- Update HDA property package to use standard names.
- Updated custom compressor example properties to use more standard names (and drop some unused properties).

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
