### PR TITLE
Fixing metadata for properties in CO2 adsorption example

### DIFF
--- a/src/Examples/Flowsheets/CO2_adsorption_desorption/NETL_32D_adsorption_reactions.py
+++ b/src/Examples/Flowsheets/CO2_adsorption_desorption/NETL_32D_adsorption_reactions.py
@@ -122,8 +122,6 @@ class ReactionParameterData(ReactionParameterBlock):
 
         self._reaction_block_class = ReactionBlock
 
-        self.default_scaling_factor = {}
-
         # Reaction Index
         self.rate_reaction_idx = Set(initialize=["R1", "R2"])
 

--- a/src/Examples/Flowsheets/CO2_adsorption_desorption/NETL_32D_gas_phase_thermo.py
+++ b/src/Examples/Flowsheets/CO2_adsorption_desorption/NETL_32D_gas_phase_thermo.py
@@ -376,7 +376,6 @@ class PhysicalParameterData(PhysicalParameterBlock):
                 "pressure": {"method": None},
                 "temperature": {"method": None},
                 "mole_frac_comp": {"method": None},
-                "mole_frac_comp_max": {"method": "_mole_frac_comp_max", "units": None},
                 "mw": {"method": "_mw"},
                 "cp_mol": {"method": "_cp_mol"},
                 "cp_mol_comp": {"method": "_cp_mol_comp"},
@@ -390,6 +389,12 @@ class PhysicalParameterData(PhysicalParameterBlock):
                 "visc_d": {"method": "_visc_d"},
                 "therm_cond": {"method": "_therm_cond"},
                 "diffusion_comp": {"method": "_diffusion_comp"},
+            }
+        )
+        
+        obj.define_custom_properties(
+            {
+                "mole_frac_comp_max": {"method": "_mole_frac_comp_max", "units": pyunits.dimensionless},
             }
         )
 

--- a/src/Examples/Flowsheets/CO2_adsorption_desorption/NETL_32D_solid_phase_thermo.py
+++ b/src/Examples/Flowsheets/CO2_adsorption_desorption/NETL_32D_solid_phase_thermo.py
@@ -208,12 +208,19 @@ class PhysicalParameterData(PhysicalParameterBlock):
                 # TODO - also use flow_mass state var if moving or bubbling fludized
                 # bed unit models are used
                 # "flow_mass": {"method": None, "units": "kg/s"},
-                "dens_mass_particle": {"method": None, "units": None},
                 "temperature": {"method": None, "units": "K"},
                 "mass_frac_comp": {"method": None, "units": None},
-                "mass_frac_comp_max": {"method": "_mass_frac_comp_max", "units": None},
                 "cp_mass": {"method": "_cp_mass", "units": "J/kg.K"},
                 "enth_mass": {"method": "_enth_mass", "units": "J/kg"},
+            }
+        )
+        
+        obj.define_custom_properties(
+            {
+                "dens_mass_particle": {"method": None,
+                                       "units": pyunits.dimensionless},
+                "mole_frac_comp_max": {"method": "_mole_frac_comp_max",
+                                       "units": pyunits.dimensionless},
             }
         )
 

--- a/src/Examples/Flowsheets/CO2_adsorption_desorption/NETL_32D_solid_phase_thermo.py
+++ b/src/Examples/Flowsheets/CO2_adsorption_desorption/NETL_32D_solid_phase_thermo.py
@@ -219,7 +219,7 @@ class PhysicalParameterData(PhysicalParameterBlock):
             {
                 "dens_mass_particle": {"method": None,
                                        "units": pyunits.dimensionless},
-                "mole_frac_comp_max": {"method": "_mole_frac_comp_max",
+                "mass_frac_comp_max": {"method": "_mass_frac_comp_max",
                                        "units": pyunits.dimensionless},
             }
         )


### PR DESCRIPTION
## Fixes None .

https://github.com/IDAES/idaes-pse/pull/995 changed how property metadata is defined, and in the process is much more strict about standard naming conventions. This example slipped through the gaps in testing, so wasn't caught when we originally updated the examples for these changes.

## Proposed changes:
- Update metadata declarations for properties in the CO2 adsorption example.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
