### PR TITLE
Update controller type arg name

### DIFF
--- a/src/Examples/DAE/pid.py
+++ b/src/Examples/DAE/pid.py
@@ -102,7 +102,7 @@ def create_model(
     m.fs.tank = Heater(has_holdup=True, material_balance_type=MaterialBalanceType.componentTotal, property_package=m.fs.prop_water)
     m.fs.valve_2 = Valve(dynamic=False, has_holdup=False, pressure_flow_callback=_valve_pressure_flow_cb, material_balance_type=MaterialBalanceType.componentTotal, property_package=m.fs.prop_water)
     # Add a controller
-    m.fs.ctrl = PIDController(process_var=m.fs.tank.control_volume.properties_out[:].pressure, manipulated_var=m.fs.valve_1.valve_opening, calculate_initial_integral=calc_integ, mv_bound_type=ControllerMVBoundType.SMOOTH_BOUND, type=ControllerType.PI)
+    m.fs.ctrl = PIDController(process_var=m.fs.tank.control_volume.properties_out[:].pressure, manipulated_var=m.fs.valve_1.valve_opening, calculate_initial_integral=calc_integ, mv_bound_type=ControllerMVBoundType.SMOOTH_BOUND, controller_type=ControllerType.PI)
     # The control volume block doesn't assume the two phases are in equilibrium
     # by default, so I'll make that assumption here, I don't actually expect
     # liquid to form but who knows. The phase_fraction in the control volume is


### PR DESCRIPTION
## Fixes:
 
There was a change in the PID controller model that renamed an argument and broke a PETSc example.  This is a fix for that.  I'm not sure if I should fix it here.  The same fix should be applied in the Example repo, but I couldn't find the example there.  I think we should merge this so the notebook isn't broken here. @dangunter, if I need to do something to also change this in Examples, let me know what to do. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.txt file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
